### PR TITLE
Compatibility with other plugins

### DIFF
--- a/lib/theme_changer_themes_patch.rb
+++ b/lib/theme_changer_themes_patch.rb
@@ -20,20 +20,25 @@ require_dependency 'redmine/themes'
 #require_dependency 'theme_changer_user_setting'
 
 module ThemeChangerThemesPatch
-  def get_theme
-    setting = ThemeChangerUserSetting.find_theme_by_user_id(User.current.id)
-    return Setting.ui_theme unless setting
-    return Setting.ui_theme if setting.theme == ThemeChangerUserSetting::SYSTEM_SETTING
-    return setting.theme_name
-  end
-  
-  def current_theme
-    unless instance_variable_defined?(:@current_theme)
-      @current_theme = Redmine::Themes.theme(get_theme)
-    end
-    @current_theme
-  end
+  def self.included(base)
+    base.class_eval do
+      def get_theme
+        setting = ThemeChangerUserSetting.find_theme_by_user_id(User.current.id)
+        return Setting.ui_theme unless setting
+        return Setting.ui_theme if setting.theme == ThemeChangerUserSetting::SYSTEM_SETTING
+        return setting.theme_name
+      end
 
+      def current_theme
+        unless instance_variable_defined?(:@current_theme)
+          @current_theme = Redmine::Themes.theme(get_theme)
+        end
+        @current_theme
+      end
+    end
+  end
 end
 
-ApplicationHelper.prepend(ThemeChangerThemesPatch)
+unless ApplicationHelper.included_modules.include?(ThemeChangerThemesPatch)
+  ApplicationHelper.include(ThemeChangerThemesPatch)
+end


### PR DESCRIPTION
Plugin fails to patch application helper if any other installed plugin requires application helper before redmine_theme_changer/ini.rb is loaded.

Here is a simple way to reproduce:
Install https://github.com/HugoHasenbein/redmine_more_filters
In user preferences select theme and go to welcome page.

Since redmine_more_filters loaded first, it requires application controller in one of its patches https://github.com/HugoHasenbein/redmine_more_filters/blob/master/lib/redmine_more_filters/patches/gantts_controller_patch.rb#L77

PR fixes it by applying patch when module is included.

More likely related to #17

